### PR TITLE
wb_port_arbiter: fix cache coherency during wb block write

### DIFF
--- a/rtl/verilog/wb_port_arbiter.v
+++ b/rtl/verilog/wb_port_arbiter.v
@@ -69,7 +69,6 @@ module wb_port_arbiter #(
 	wire				wbp_ack_o[WB_PORTS-1:0];
 
 	wire				wb_cycle[WB_PORTS-1:0];
-	reg				wb_cycle_r[WB_PORTS-1:0];
 
 	wire [31:0]			p_adr_i[WB_PORTS-1:0];
 	wire [31:0]			p_adr_o[WB_PORTS-1:0];
@@ -108,9 +107,6 @@ module wb_port_arbiter #(
 		assign p_adr_i[i] = adr_i;
 		assign p_dat_i[i] = dat_i;
 		assign p_ack_i[i] = ack_i & port_sel[i];
-
-		always @(posedge wb_clk)
-			wb_cycle_r[i] <= wb_cycle[i];
 
 		wb_port #(
 			.TECHNOLOGY	(TECHNOLOGY),
@@ -215,9 +211,8 @@ module wb_port_arbiter #(
 			p_bufw_dat[k] <= 0;
 			p_bufw_sel[k] <= 0;
 			for (j = 0; j < WB_PORTS; j=j+1) begin
-				if (j!=k & wb_cycle[j] &
-				    !wb_cycle_r[j] & wb_we_i[j]) begin
-					p_bufw_we[k]  <= 1'b1;
+				if (j!=k & wb_cycle[j] & wb_we_i[j]) begin
+					p_bufw_we[k]  <= wbp_ack_o[j];
 					p_bufw_adr[k] <= wbp_adr_i[j];
 					p_bufw_dat[k] <= wbp_dat_i[j];
 					p_bufw_sel[k] <= wbp_sel_i[j];


### PR DESCRIPTION
Multiples write can occur during a single write block cycle.

Old code triggers a buffer write on the rising edge of wb_cyc.
This only works with single write cycles.

This patch signals that a write have happend to all ports
on every wb_ack during the write block cycle.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
