### PR TITLE
sdram_ctrl: Add param for refresh cycle

### DIFF
--- a/rtl/verilog/sdram_ctrl.v
+++ b/rtl/verilog/sdram_ctrl.v
@@ -26,6 +26,7 @@
 module sdram_ctrl #(
 	parameter CLK_FREQ_MHZ	= 100,	// sdram_clk freq in MHZ
 	parameter POWERUP_DELAY	= 200,	// power up delay in us
+	parameter REFRESH_MS	= 64,	// time to wait between refreshes in ms
 	parameter BURST_LENGTH	= 8,	// 0, 1, 2, 4 or 8 (0 = full page)
 	parameter ROW_WIDTH	= 13,	// Row width
 	parameter COL_WIDTH	= 9,	// Column width
@@ -68,7 +69,7 @@ module sdram_ctrl #(
 
 	localparam POWERUP_CNT = CLK_FREQ_MHZ*POWERUP_DELAY;
 	// refresh should be done for each row every 64 ms => 64e-3/2^ROW_WIDTH
-	localparam REFRESH_TIMEOUT = (CLK_FREQ_MHZ*64000)/(1<<ROW_WIDTH);
+	localparam REFRESH_TIMEOUT = (CLK_FREQ_MHZ*REFRESH_MS*1000)/(1<<ROW_WIDTH);
 
 	// Burst types
 	localparam

--- a/rtl/verilog/wb_sdram_ctrl.v
+++ b/rtl/verilog/wb_sdram_ctrl.v
@@ -27,6 +27,7 @@ module wb_sdram_ctrl #(
 	parameter TECHNOLOGY	= "GENERIC",
 	parameter CLK_FREQ_MHZ	= 100,	// sdram_clk freq in MHZ
 	parameter POWERUP_DELAY	= 200,	// power up delay in us
+	parameter REFRESH_MS	= 64,	// time to wait between refreshes in ms
 	parameter BURST_LENGTH	= 8,	// 0, 1, 2, 4 or 8 (0 = full page)
 	parameter WB_PORTS	= 3,	// Number of wishbone ports
 	parameter BUF_WIDTH	= 3,	// Buffer size = 2^BUF_WIDTH
@@ -83,6 +84,7 @@ module wb_sdram_ctrl #(
 	sdram_ctrl #(
 		.CLK_FREQ_MHZ	(CLK_FREQ_MHZ),
 		.POWERUP_DELAY	(POWERUP_DELAY),
+		.REFRESH_MS	(REFRESH_MS),
 		.BURST_LENGTH	(BURST_LENGTH),
 		.ROW_WIDTH	(ROW_WIDTH),
 		.COL_WIDTH	(COL_WIDTH),


### PR DESCRIPTION
Different sdram has different refresh requirements,  the default of
64 was causing some issues on my de0 nano board.  I confirmed there
were no issues when I bumped it down to 32.

Signed-off-by: Stafford Horne <shorne@gmail.com>